### PR TITLE
Expose transient keymap and its functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ An example of a more advanced configuration:
   :config
 
   (setq wingman-log-level 4)
-  (setq wingman-key-accept-full (kbd "TAB"))
   (setq wingman-ring-n-chunks 16)
 
   ;; default llama.cpp server port is 8012
@@ -93,7 +92,13 @@ An example of a more advanced configuration:
                        (let ((fname (file-name-nondirectory buffer-file-name)))
                          (or (string-equal ".env" fname)
                              (string-equal ".envrc" fname)
-                             (string-prefix-p ".localrc" fname))))))))
+                             (string-prefix-p ".localrc" fname)))))))
+
+  :bind
+  (:map wingman-mode-completion-transient-map
+   ("TAB" . wingman-accept-full)
+   ("S-TAB" . wingman-accept-line)
+   ("M-S-TAB" . wingman-accept-word)))
 ```
 
 ## Usage

--- a/wingman.el
+++ b/wingman.el
@@ -271,8 +271,7 @@ For example:
     (remove-hook 'after-save-hook #'wingman--pick-chunk-on-save t)
     (remove-hook 'yank-post-process-hook #'wingman--pick-chunk-on-yank t)
     (remove-hook 'kill-buffer-hook #'wingman--cleanup t)
-    (wingman-hide)
-    (wingman--cancel-timer-if-unused)))
+    (wingman--cleanup)))
 
 (defun wingman--ring-update-dispatch ()
   "Called by the single global timer to process the global chunk queue."
@@ -675,6 +674,7 @@ and ping server so it is cached."
 (defun wingman--cleanup ()
   "Buffer-local cleanup when wingman-mode is disabled or buffer is killed."
   (wingman-hide)
+  (wingman--cancel-timer-if-unused)
   (when wingman--current-request
     (request-abort wingman--current-request))
   (setq wingman--ring-evict 0))

--- a/wingman.el
+++ b/wingman.el
@@ -137,18 +137,6 @@ For example:
   :type '(choice (const :tag "Unbound" nil) key-sequence)
   :group 'wingman)
 
-(defcustom wingman-key-accept-full (kbd "TAB")
-  "Key that accepts full suggestion."
-  :type 'key-sequence)
-
-(defcustom wingman-key-accept-line (kbd "S-TAB")
-  "Key that accepts only first line."
-  :type 'key-sequence)
-
-(defcustom wingman-key-accept-word (kbd "M-S-TAB")
-  "Key that accepts only first word."
-  :type 'key-sequence)
-
 (defcustom wingman-ring-n-chunks 16 "Maximum extra chunks." :type 'integer)
 (defcustom wingman-ring-chunk-size 64 "Lines per chunk." :type 'integer)
 (defcustom wingman-ring-scope 1024  "How far around point to harvest." :type 'integer)
@@ -249,13 +237,11 @@ For example:
     m)
   "Local map for wingman-mode.")
 
-(defvar wingman-mode-completion-transient-map
-  (let ((m (make-sparse-keymap)))
-    (define-key m wingman-key-accept-full #'wingman-accept-full)
-    (define-key m wingman-key-accept-line #'wingman-accept-line)
-    (define-key m wingman-key-accept-word #'wingman-accept-word)
-    m)
-  "Local map for wingman-mode while there is an active completion.")
+(defvar-keymap wingman-mode-completion-transient-map
+  :doc "Local map for wingman-mode while there is an active completion."
+  "TAB" #'wingman-accept-full
+  "S-TAB" #'wingman-accept-line
+  "M-S-TAB" #'wingman-accept-word)
 
 ;;;###autoload
 (define-minor-mode wingman-mode


### PR DESCRIPTION
This adds some flexibility in how wingman may be configured. For example, it is now possible to customize keybindings in this way:

```emacs-lisp
(use-package wingman
  :bind
  (:map wingman-mode-completion-transient-map
   ("C-c a f" . wingman-accept-full)
   ("C-c a l" . wingman-accept-line)
   ("C-c a w" . wingman-accept-word)))
```