### PR TITLE
Switch to a prefix key and map, removing `wingman-key-trigger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ An example of a more advanced configuration:
 
   :init
 
-  (setq wingman-key-trigger (kbd "C-c a z"))
+  (setq wingman-prefix-key (kbd "C-c w"))
 
   :hook (prog-mode . wingman-mode)
 
@@ -95,7 +95,9 @@ An example of a more advanced configuration:
                              (string-prefix-p ".localrc" fname)))))))
 
   :bind
-  (:map wingman-mode-completion-transient-map
+  (:map wingman-mode-prefix-map
+   ("TAB" . wingman-fim-inline)
+   :map wingman-mode-completion-transient-map
    ("TAB" . wingman-accept-full)
    ("S-TAB" . wingman-accept-line)
    ("M-S-TAB" . wingman-accept-word)))
@@ -106,7 +108,7 @@ An example of a more advanced configuration:
 1. **Enable the mode:** `wingman-mode` is a buffer-local minor mode. You can enable it with `M-x wingman-mode` or have it enabled automatically via the hook as shown above.
 2. **Get Completions:**
    * If `wingman-auto-fim` is `t` (the default), completions will appear automatically as you type.
-   * To manually request a completion, press the trigger key (customized via `wingman-key-trigger`).
+   * To manually request a completion, use `wingman-fim-inline`. By default this is bound to `C-c w TAB` in the `wingman-mode-map`, and may be customized via `wingman-prefix-key` and `wingman-mode-prefix-map`.
 3. **Accept a Completion:**
    * **Full:** Press the "accept full" key (default: `<tab>`) to insert the entire suggestion.
    * **Line:** Press the "accept line" key (default: `S-TAB`) to insert only the first line of the suggestion.

--- a/wingman.el
+++ b/wingman.el
@@ -125,16 +125,9 @@ Example:
   :type '(repeat function)
   :group 'wingman)
 
-(defcustom wingman-key-trigger nil
-  "Keybinding that explicitly requests completion.
-
-This is unbound by default to avoid conflicts with user
-configurations. To bind a key for this command, set this
-variable in your init file before `wingman-mode` is loaded.
-For example:
-
-  (setq wingman-key-trigger (kbd \"C-c l\"))"
-  :type '(choice (const :tag "Unbound" nil) key-sequence)
+(defcustom wingman-prefix-key "C-c w"
+  "Key in the `wingman-mode-map' prefixing the `wingman-mode-prefix-map'."
+  :type '(choice (const :tag "Unbound" nil) key)
   :group 'wingman)
 
 (defcustom wingman-ring-n-chunks 16 "Maximum extra chunks." :type 'integer)
@@ -230,12 +223,18 @@ For example:
   "Hook function for `yank-post-process-hook' to pick a chunk."
   (wingman--pick-chunk))
 
+(defvar-keymap wingman-mode-prefix-map
+  :doc "Local map for wingman-mode. Will be prefixed by `wingman-prefix-key' in
+the `wingman-mode-map' map."
+  "TAB" #'wingman-fim-inline)
+
 (defvar wingman-mode-map
-  (let ((m (make-sparse-keymap)))
-    (when wingman-key-trigger
-      (define-key m wingman-key-trigger #'wingman-fim-inline))
-    m)
-  "Local map for wingman-mode.")
+  (let ((map (make-sparse-keymap)))
+    (when wingman-prefix-key
+      (define-key map (kbd wingman-prefix-key) wingman-mode-prefix-map))
+    map)
+  "Keymap for wingman-mode. Keybindings will use the prefix as defined by
+`wingman-prefix-key'.")
 
 (defvar-keymap wingman-mode-completion-transient-map
   :doc "Local map for wingman-mode while there is an active completion."


### PR DESCRIPTION
Switches to a prefix key and map, and removes `wingman-key-trigger`.

I would consider this to be more idiomatic. There are examples of prefix key maps that are part of Emacs, such as `window-prefix-map` and `project-prefix-map`. The main advantage is you can take the bundle of keybindings and nest them under any other prefix, without having to rebind everything manually. 

For now there is only `TAB`, but having the prefix map may be helpful in the future as more commands are added.  