### PR TITLE
Fix `wingman--extra-context` alist key types

### DIFF
--- a/wingman.el
+++ b/wingman.el
@@ -503,9 +503,9 @@ the `wingman-mode-map' map."
                   (length project-chunks) (or current-project-root "global"))
     (vconcat
      (mapcar (lambda (c)
-               `(("text" . ,(wingman--chunk-string c))
-                 ("time" . ,(wingman--chunk-timestamp c))
-                 ("filename" . ,(wingman--chunk-filename c))))
+               `((text . ,(wingman--chunk-string c))
+                 (time . ,(wingman--chunk-timestamp c))
+                 (filename . ,(wingman--chunk-filename c))))
              project-chunks))))
 
 (defun wingman--render (raw indent buf)


### PR DESCRIPTION
`wingman-debug-completion` expects the keys to be symbols. This shouldn't have any effect on completion with the server, since `json-encode` will encode the symbols as JSON strings. 