### PR TITLE
Add `global-wingman-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ An example of a more advanced configuration:
 
 ## Usage
 
-1. **Enable the mode:** `wingman-mode` is a buffer-local minor mode. You can enable it with `M-x wingman-mode` or have it enabled automatically via the hook as shown above.
+1. **Enable the mode:** `wingman-mode` is a buffer-local minor mode. You can enable it with `M-x wingman-mode`, or globally in all applicable buffers with `global-wingman-mode`. (Alternatively, you may enable `wingman-mode` automatically via the hook as shown in the configuration examples above.)
 2. **Get Completions:**
    * If `wingman-auto-fim` is `t` (the default), completions will appear automatically as you type.
    * To manually request a completion, use `wingman-fim-inline`. By default this is bound to `C-c w TAB` in the `wingman-mode-map`, and may be customized via `wingman-prefix-key` and `wingman-mode-prefix-map`.

--- a/wingman.el
+++ b/wingman.el
@@ -273,6 +273,17 @@ the `wingman-mode-map' map."
       (remove-hook 'kill-buffer-hook #'wingman--cleanup t)
       (wingman--cleanup))))
 
+(defun wingman--maybe-enable-mode ()
+  "Enable `wingman-mode' in the current buffer if it is not already
+enabled, and only if it may be enabled as determined by `wingman-disable-predicates'."
+  (when (and (not wingman-mode) (not (wingman--should-be-disabled-p)))
+    (wingman-mode 1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-wingman-mode wingman-mode
+  wingman--maybe-enable-mode
+  :group 'wingman)
+
 (defun wingman--ring-update-dispatch ()
   "Called by the single global timer to process the global chunk queue."
   (wingman--ring-update)


### PR DESCRIPTION
Adds a `global-wingman-mode`. 

The purpose of `wingman--maybe-enable-mode` is so that the global mode silently skips buffers the mode won't be enabled in. In part this preempts the "wingman-mode: Disabled in this buffer due to configuration." message that `wingman-mode` emits. 