### PR TITLE
Keep the cursor at the beginning of the overlay

### DIFF
--- a/wingman.el
+++ b/wingman.el
@@ -713,7 +713,12 @@ If POS-MARKER is non-nil, render at that marker position."
                   (setcar (last accept-content-lines)
                           (concat (car (last accept-content-lines)) current-suffix)))
 
-                (overlay-put first-ov 'after-string (propertize display-first-line 'face 'wingman-overlay-face))
+                (let* ((text display-first-line)
+                       (len (length text)))
+                  (put-text-property 0 1 'cursor len text)
+                  (put-text-property 0 len 'face 'wingman-overlay-face text))
+
+                (overlay-put first-ov 'after-string display-first-line)
                 (overlay-put first-ov 'wingman t)
                 (setq wingman--hint-overlay first-ov)
 


### PR DESCRIPTION
Before: the cursor jumps to the end of the overlay.
Now: the cursor stays where it is, and the proposed text comes after the cursor.